### PR TITLE
Fix for stuck consumer if item is ignored

### DIFF
--- a/lib/Data/Consumer/MySQL2.pm
+++ b/lib/Data/Consumer/MySQL2.pm
@@ -323,7 +323,10 @@ sub acquire {
         $self->debug_warn( 5, "last_id was $self->{last_id}");
         my ($id)= $dbh->selectrow_array( $self->{select_sql}, undef, $self->{last_id}, @{ $self->{select_args} || [] } );
         if ( defined $id ) {
-            next if $self->is_ignored($id);
+            if ( $self->is_ignored($id) ) {
+                $self->{last_id}= $id;
+                next;
+            }
             my ($got_id) = $dbh->selectrow_array( $self->{check_sql}, undef, $id, @{ $self->{check_args} || [] } );
             if ( not defined $got_id) {
                 $self->debug_warn(5, "race condition avoided for '$id', check_sql and select_sql did not line up!");

--- a/t/07-mysql-ignore.t
+++ b/t/07-mysql-ignore.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Cwd;
+our %process_state = (
+    unprocessed => 94,
+    processed   => 10,
+    working => 123,
+    failed => 666,
+);
+
+our $object='Data::Consumer';
+our @expect_fail=([3,0,94]);
+our %ignored=(3=>1);
+
+%ignored = %ignored; #silence warnings on 5.6.2
+@expect_fail = @expect_fail; #silence warnings on 5.6.2
+$object = $object; #silence warnings on 5.6.2
+%process_state = %process_state; # silence warnings on 5.6.2
+
+my $file='t/01-mysql.t';
+my $res = do $file;
+if (!defined $res) {
+    die "Error executing '$file': ",$@||$!,"\nCwd=". cwd(),"\n";
+}
+
+


### PR DESCRIPTION
Fixed consumer getting stuck in acquire() after item is explicitly ignored

Without a fix, if we encounter this scenario, we will get an infinite loop in acquire():
1. start consuming
2. explicitly ignore() any item
3. continue consuming
4. wait till reset() is called (queue is exhausted or consume() called again)
5. try consume more items
6. acquire() receives already ignored item
    7. item is ignored but $self->{last_id} is not updated
    8. we skip item and loop back to 6, where process same item again

Fix just updates $self->{last_id} when we skip an ignored item. This
logic is similar to original logic in Data::Consumer::MySQL.

Also added test case for this scenario.